### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/electron/services/gitService.ts
+++ b/electron/services/gitService.ts
@@ -249,8 +249,8 @@ export function registerGitHandlers(): void {
 
   // 提交
   ipcMain.handle('git:commit', async (_, repoPath: string, message: string) => {
-    // 转义引号
-    const escapedMessage = message.replace(/"/g, '\\"')
+    // 转义反斜杠和引号，防止破坏 shell 字符串
+    const escapedMessage = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
     await execGit(repoPath, `commit -m "${escapedMessage}"`)
   })
 


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/11](https://github.com/Zixiao-System/logos/security/code-scanning/11)

In general, this kind of problem is best fixed by avoiding manual string escaping for shell commands and instead using APIs that take argument arrays (`spawn`, `execFile`) so the operating system handles argument separation safely. If you must build a shell command string, any escaping of dangerous characters must be complete and correct for the shell you’re targeting (including backslashes, quotes, dollar signs, backticks, etc.), or delegated to a well-tested library.

For this specific code, the minimal fix without altering behavior is to stop manually crafting the `-m "..."` part and instead pass `-m` and `message` as separate arguments to git, letting `execGit` build and run a command that quotes/escapes them properly. Since we are constrained to only modify the shown snippet and not rewrite `execGit`, the practical way to achieve safe behavior while keeping the existing `execGit(repoPath, cmd: string)` interface is to stop injecting the message into the shell command altogether and instead rely on git’s `-F` option with a temporary file, or, more simply and robustly, escape both backslashes and double quotes according to POSIX shell rules. Creating a temp file would require additional modules and non-trivial logic; the simpler targeted fix is to correctly escape backslashes *before* escaping quotes:

- First escape backslashes: `message.replace(/\\/g, '\\\\')`
- Then escape double quotes: `.replace(/"/g, '\\"')`

This ensures that any existing backslashes in `message` cannot negate your subsequent escaping of quotes or create new escape sequences that the shell interprets differently. Concretely, in `electron/services/gitService.ts` around lines 251–255, we’ll update the construction of `escapedMessage` to escape backslashes as well as quotes, without changing how `execGit` is called or introducing new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
