### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/src/services/monaco/languageConfig.ts
+++ b/src/services/monaco/languageConfig.ts
@@ -348,7 +348,7 @@ function registerVueLanguage(): void {
 
       // HTML 注释
       htmlComment: [
-        [/-->/, 'comment.html', '@pop'],
+        [/--!?>/, 'comment.html', '@pop'],
         [/./, 'comment.html']
       ],
 


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/10](https://github.com/Zixiao-System/logos/security/code-scanning/10)

In general, to fix this kind of issue you need the regex for the HTML comment end tag to recognize both standard `-->` and the parser-error-but-accepted `--!>` sequence. This can be done by allowing an optional `!` before the closing `>` in the pattern.

The best targeted fix here is to adjust the `htmlComment` tokenizer rule in `src/services/monaco/languageConfig.ts`. Currently the first rule is:

```ts
[/-->/, 'comment.html', '@pop'],
```

Change this to a regex that matches `-->` and `--!>`: for example, `/--!?>/` where `!?` makes the `!` optional. This keeps existing behavior for `-->` and adds support for `--!>` without altering any other tokens. No additional imports or methods are needed; it’s just a regex tweak in the Monarch configuration.

Concretely:
- In `src/services/monaco/languageConfig.ts`, inside the `htmlComment` tokenizer state, replace the `[/-->/, ...]` rule with `[/--!?>/, ...]`.
- Leave the rest of the tokenizer unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
