### PR TITLE
Potential fix for code scanning alert no. 9: Bad HTML filtering regexp

### DIFF
--- a/src/services/monaco/languageConfig.ts
+++ b/src/services/monaco/languageConfig.ts
@@ -57,7 +57,7 @@ function registerVueLanguage(): void {
     wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
     indentationRules: {
       increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
-      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/
+      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|--!?>|\})/
     }
   })
 


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/9](https://github.com/Zixiao-System/logos/security/code-scanning/9)

In general terms, the fix is to update the regular expression used to detect HTML comment end tags so that it recognizes both `-->` and `--!>`, instead of only the former. This can be done by replacing the hard‑coded `-->` sequence with a pattern that allows an optional `!` before the closing `>`.

Concretely, in `src/services/monaco/languageConfig.ts`, within the `registerVueLanguage` function, the `decreaseIndentPattern` currently includes an alternation branch `-->` inside the regexp: `^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})`. To fix the issue without changing existing functionality, we keep the overall structure and only modify that branch to match both `-->` and `--!>`. The simplest change is to use `--!?>`, which means two hyphens, an optional exclamation mark, then `>`. The updated regexp becomes: `^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|--!?>|\})`. No new methods or imports are needed; we only adjust the regexp literal in this one line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
