### PR TITLE
Potential fix for code scanning alert no. 8: Insecure randomness

### DIFF
--- a/electron/services/debug/debugService.ts
+++ b/electron/services/debug/debugService.ts
@@ -7,6 +7,7 @@ import { BrowserWindow } from 'electron'
 import { ChildProcess } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
+import * as crypto from 'crypto'
 import { DAPClient } from './DAPClient'
 import type {
   DebugSession,
@@ -622,7 +623,11 @@ export class DebugService extends EventEmitter {
   // ============ Private Methods ============
 
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    // Use cryptographically secure randomness for session identifiers
+    const randomPart = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : crypto.randomBytes(16).toString('hex')
+    return `session_${Date.now()}_${randomPart}`
   }
 
   private getSessionEntry(sessionId?: string) {


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/8](https://github.com/Zixiao-System/logos/security/code-scanning/8)

In general, to fix this issue, replace uses of `Math.random()` for generating identifiers used in a security‑relevant or potentially exposed context with Node’s cryptographically secure randomness from the `crypto` module. Appropriate options are `crypto.randomUUID()` (for a ready‑made string ID) or `crypto.randomBytes()` combined with base‑encoding.

For this specific code, the simplest, non‑breaking change is to keep the `session_` prefix so existing log patterns and expectations remain intact, but generate the random suffix using `crypto.randomUUID()`. That keeps the return type (`string`) and format (“session_…”) while making the ID effectively unguessable. Concretely:

- Add an import for Node’s built‑in `crypto` module at the top of `electron/services/debug/debugService.ts` without modifying existing imports.
- Update `generateSessionId()` so it no longer calls `Math.random()`. Either:
  - Replace the entire ID with `crypto.randomUUID()`, or
  - Preserve the existing prefix and timestamp and use `crypto.randomUUID()` for the random portion. I’ll choose the latter to minimize behavior changes while fully addressing the security concern.

No new helper methods are required beyond the added import; we only alter the body of `generateSessionId()` and add the `crypto` import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
