### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -377,6 +377,7 @@ jobs:
     needs: [build, publish-release, homebrew, aur, update-docs]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check job results
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/7](https://github.com/Zixiao-System/logos/security/code-scanning/7)

In general, fix this by explicitly declaring a `permissions` block either at the workflow root or per job, choosing the minimal scopes needed. Jobs that do not need to access the GitHub API or repository contents can have `permissions: {}` or `permissions: read-all` depending on needs.

For this workflow, only the `notify` job is missing explicit permissions in the snippet. That job simply prints the results of other jobs and does not interact with the repository or GitHub APIs, so it does not require any token permissions. The safest and most precise fix is to add `permissions: {}` to the `notify` job, which disables the `GITHUB_TOKEN` for that job while keeping all existing behavior intact.

Concretely, in `.github/workflows/Release.yml`, under the `notify` job (around line 375), add a `permissions: {}` line at the same indentation level as `needs`, `if`, and `runs-on`. No other imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
