### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -264,6 +264,8 @@ jobs:
     needs: [build, publish-release]
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
       - name: Check for SSH key
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/6](https://github.com/Zixiao-System/logos/security/code-scanning/6)

To fix this, explicitly define a minimal `permissions` block for the `aur` job so that `GITHUB_TOKEN` does not inherit potentially broad repository defaults. The job only needs to read from the repository (via `actions/checkout`), so `contents: read` is sufficient. We should add a `permissions` section under `aur:` similar to the existing `update-docs` job but restricted to read-only.

Concretely:
- In `.github/workflows/Release.yml`, locate the `aur:` job definition starting at line 262.
- Add a `permissions:` block under the job (aligned with `needs`, `runs-on`, etc.) with `contents: read`.
- No other functionality changes are needed; we are only tightening the `GITHUB_TOKEN` scope.
- No additional imports or methods are required, as this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
