### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -187,6 +187,8 @@ jobs:
     needs: [build, publish-release]
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
       - name: Check for token
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/5](https://github.com/Zixiao-System/logos/security/code-scanning/5)

In general, the fix is to explicitly declare a minimal `permissions` block for the `homebrew` job so it does not inherit broad repository defaults for the `GITHUB_TOKEN`. Since the job only needs to read repository contents and artifacts, `contents: read` is an appropriate minimal permission.

Concretely, in `.github/workflows/Release.yml`, under the `homebrew` job definition (around line 185), add a `permissions:` section similar to the one already used in the `publish-release` job but restricted to `contents: read`. Place it alongside existing job-level keys (`needs`, `runs-on`, `continue-on-error`) so that only this job’s token is restricted, without affecting others. No imports or additional methods are necessary; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
