### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -1,4 +1,6 @@
 name: Check & Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/4](https://github.com/Zixiao-System/logos/security/code-scanning/4)

In general, the fix is to explicitly declare `permissions` either at the top level of the workflow (applying to all jobs that don’t override it) or per job, and reduce the `GITHUB_TOKEN` to the minimal scopes needed. For jobs that only need to read the repository contents and use Actions features, `contents: read` is usually sufficient. If no write operations against issues, PRs, or releases occur in this workflow, we can safely set all permissions to read-only or even `permissions: {}` for jobs that don’t use the token.

For this specific workflow, all three jobs (`checks`, `rust-check`, and `build`) only read the repository and build artifacts; there is no code in the snippet that modifies repository state or creates releases via the GitHub API. The `build` job does pass `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` into `npm run build`, but absent evidence of write needs, we can still restrict the token to read-only repository contents. The simplest, least-invasive, and functionally preserving fix is to add a root-level `permissions` block with `contents: read`. This will apply to all jobs and limit the default `GITHUB_TOKEN` appropriately without changing any steps.

Concretely, in `.github/workflows/Check.yml`, insert a `permissions:` section after the `name:` stanza and before the `on:` block:

```yml
name: Check & Build
permissions:
  contents: read

on:
  ...
```

No imports or additional methods are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
