### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -22,6 +22,8 @@ jobs:
   # ============================================
   build:
     name: Build (${{ matrix.os }})
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/Zixiao-System/logos/security/code-scanning/2](https://github.com/Zixiao-System/logos/security/code-scanning/2)

In general, to fix this issue you should explicitly set the `permissions` for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the minimal scopes required. Here, the problem is the missing `permissions` on the `build` job. The `publish-release` job already has `permissions: contents: write`, so we only need to add a block for `build`.

The best targeted fix without changing functionality is to add a `permissions` block under the `build` job (line 23) to explicitly allow the token to write repository contents (which is what electron-builder and `gh` typically need for releases), instead of relying on inherited defaults. Since we cannot inspect `npm run build`, reducing it to `contents: read` might break the workflow; therefore we will mirror the level of access already explicitly granted to the `publish-release` job: `contents: write`. Concretely, in `.github/workflows/Release.yml`, add:

```yaml
    permissions:
      contents: write
```

indented to align with `name:`, `strategy:`, etc. under the `build` job.

No additional imports, tools, or methods are needed beyond this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
